### PR TITLE
[requirements.txt] add missig line_profiler in PIP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ ipdb
 plotly
 jupyter_contrib_nbextensions
 jupyter_nbextensions_configurator
+line_profiler


### PR DESCRIPTION
line_profiler is required in notebooks/test_model.ipynb