### PR TITLE
Use torch.div

### DIFF
--- a/src/lanczos.py
+++ b/src/lanczos.py
@@ -36,7 +36,7 @@ def lanczos_kernel(dx, a=3, N=None, dtype=None, device=None):
     if (N is None) or (N < S_max):
         N = S
 
-    Z = (N - S) // 2  # width of zeros beyond kernel support
+    Z = torch.div((N - S), 2, rounding_mode='trunc')  # width of zeros beyond kernel support
 
     start = (-(a + D + Z)).min()
     end = (a + D + Z + 1).max()


### PR DESCRIPTION
Prevent a UserWarning :

/HighRes-net/src/lanczos.py:39: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').
  Z = (N - S) // 2  # width of zeros beyond kernel support